### PR TITLE
Update flatpickr version to 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "yiisoft/yii2": "*",
-        "bower-asset/flatpickr": "^3.0"
+        "bower-asset/flatpickr": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I'm using the current version (on flatpickr 3.x). Themes and plugin options aren't working, and the datepicker always reveals downwards even when the form is at the bottom of the page/viewing area. On the official site, this does not happen.